### PR TITLE
fix fmtDuration

### DIFF
--- a/formatting.go
+++ b/formatting.go
@@ -10,11 +10,7 @@ import (
 )
 
 func fmtDuration(d time.Duration) string {
-	d = d.Round(time.Second)
-	minutes := d / time.Minute
-	d -= minutes * time.Minute
-	seconds := d / time.Second
-	return fmt.Sprintf("%02d:%02d", minutes, seconds)
+	return d.String()
 }
 
 func durationBar(width int, fraction time.Duration, total time.Duration) string {


### PR DESCRIPTION
Fix questionable time formatting.

Should be fine to use `time.Duration.String()`, alternatively to keep old formatting use this:

```go
func fmtDuration(d time.Duration) string {
	minutes := int(d.Minutes())
	seconds := int(d.Seconds()) % 60
	return fmt.Sprintf("%d:%d", minutes, seconds)
}
```